### PR TITLE
Change feed validation to post instead of get.

### DIFF
--- a/lib/w3c_validators/feed_validator.rb
+++ b/lib/w3c_validators/feed_validator.rb
@@ -51,7 +51,7 @@ module W3CValidators
 protected
     def validate(options) # :nodoc:
       options = get_request_options(options)
-      response = send_request(options, :get)
+      response = send_request(options, :post)
       @results = parse_soap_response(response.body)
       @results
     end


### PR DESCRIPTION
Per RFC nontrivial amounts of data should be sent via HTTP POST rather than GET.  W3C was returning 414 errors for modestly sized Atom submitted via GET.
