### PR TITLE
Integer Unification for Ruby 2.4.0+

### DIFF
--- a/lib/w3c_validators/markup_validator.rb
+++ b/lib/w3c_validators/markup_validator.rb
@@ -153,7 +153,7 @@ protected
 
       # Convert booleans to integers
       [:fbc, :fbd, :verbose, :debug, :ss, :outline].each do |k|
-        if options.has_key?(k) and not options[k].kind_of?(Fixnum)
+        if options.has_key?(k) and not options[k].kind_of?(Integer)
           options[k] = options[k] ? 1 : 0
         end
       end


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warning in Ruby 2.4.0-rc1.

`warning: constant ::Fixnum is deprecated`

Thanks.