### PR TITLE
add deprecation warning for MarkupValidator class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -58,3 +58,6 @@
  * relax constraint on json gem to >=1.8 instead of ~>2.0
  * add test of ruby 2.4.0 + drop test of ruby 2.0.0
 
+== Next version
+ * add deprecation warning for class MarkupValidator
+

--- a/lib/w3c_validators/markup_validator.rb
+++ b/lib/w3c_validators/markup_validator.rb
@@ -14,6 +14,7 @@ module W3CValidators
     #
     # See Validator#new for proxy server options.
     def initialize(options = {})
+      puts "The MarkupValidator class is deprecated (cf. https://validator.w3.org/docs/obsolete-api.html) as it cannot process HTML5 documents.\nPlease prefer the NuValidator class instead."
       if options[:validator_uri]
         @validator_uri = URI.parse(options[:validator_uri])
         options.delete(options[:validator_uri])


### PR DESCRIPTION
Keep the class, but raise a deprecation warning (as suggested in https://github.com/w3c-validators/w3c_validators/issues/25#issuecomment-282505725)