### PR TITLE
Add Errno::ECONNREFUSED to handled exceptions

### DIFF
--- a/lib/w3c_validators/validator.rb
+++ b/lib/w3c_validators/validator.rb
@@ -174,7 +174,7 @@ module W3CValidators
     #++
     def handle_exception(e, msg = '') # :nodoc:
       case e
-        when Net::HTTPServerException, SocketError
+        when Net::HTTPServerException, SocketError, Errno::ECONNREFUSED
           msg = "unable to connect to the validator at #{@validator_uri} (response was #{e.message})."
           raise ValidatorUnavailable, msg, caller
         when JSON::ParserError, Nokogiri::XML::SyntaxError

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -17,7 +17,7 @@ class ExceptionTests < Test::Unit::TestCase
     VCR.turned_off do
       WebMock.allow_net_connect!
       ['http://noexist/', 'http://noexist.badtld/',
-       'http://example.com/noexist'].each do |uri|
+       'http://example.com/noexist', 'http://localhost:9999/'].each do |uri|
         v = MarkupValidator.new(:validator_uri => uri)
         assert_raise ValidatorUnavailable do
           v.validate_text(@valid_fragment)


### PR DESCRIPTION
With custom validator uri and not started validator silently fail and exit
This allow to have an error when the service is not started
Cheers