### PR TITLE
Version 1.3.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -68,3 +68,8 @@
  * add test of ruby 2.5
  * remove unused variable in nu validator code
 
+== Version 1.3.5
+ * replace Net::HTTPServerException (deprecated) by Net::HTTPClientException
+ * fix bad indentation of rescue in validators classes
+ * add test for ruby 2.6, update 2.5, 2.4, 2.3 tested version and remove 2.2 and 2.1 versions
+

--- a/lib/w3c_validators/validator.rb
+++ b/lib/w3c_validators/validator.rb
@@ -16,6 +16,7 @@ module W3CValidators
     HEAD_STATUS_HEADER        = 'X-W3C-Validator-Status'
     HEAD_ERROR_COUNT_HEADER   = 'X-W3C-Validator-Errors'
     SOAP_OUTPUT_PARAM         = 'soap12'
+    USE_NEW_EXCEPTION         = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
 
     attr_reader :results, :validator_uri
 
@@ -173,8 +174,13 @@ module W3CValidators
     # Big thanks to ara.t.howard and Joel VanderWerf on Ruby-Talk for the exception handling help.
     #++
     def handle_exception(e, msg = '') # :nodoc:
+      if USE_NEW_EXCEPTION
+        http_exception = Net::HTTPClientException
+      else
+        http_exception = Net::HTTPServerException
+      end
       case e
-        when Net::HTTPClientException, SocketError, Errno::ECONNREFUSED
+        when http_exception, SocketError, Errno::ECONNREFUSED
           msg = "unable to connect to the validator at #{@validator_uri} (response was #{e.message})."
           raise ValidatorUnavailable, msg, caller
         when JSON::ParserError, Nokogiri::XML::SyntaxError

--- a/lib/w3c_validators/validator.rb
+++ b/lib/w3c_validators/validator.rb
@@ -174,7 +174,7 @@ module W3CValidators
     #++
     def handle_exception(e, msg = '') # :nodoc:
       case e
-        when Net::HTTPServerException, SocketError, Errno::ECONNREFUSED
+        when Net::HTTPClientException, SocketError, Errno::ECONNREFUSED
           msg = "unable to connect to the validator at #{@validator_uri} (response was #{e.message})."
           raise ValidatorUnavailable, msg, caller
         when JSON::ParserError, Nokogiri::XML::SyntaxError

--- a/lib/w3c_validators/version.rb
+++ b/lib/w3c_validators/version.rb
@@ -1,3 +1,3 @@
 module W3CValidators
-  VERSION = "1.3.4"
+  VERSION = "1.3.5"
 end


### PR DESCRIPTION
Version 1.3.5
* replace Net::HTTPServerException (deprecated) by Net::HTTPClientException
* fix bad indentation of rescue in validators classes
* add test for ruby 2.6, update 2.5, 2.4, 2.3 tested version and remove 2.2 and 2.1 versions
